### PR TITLE
Turn off no-underscore-dangle

### DIFF
--- a/.eslintrc-default
+++ b/.eslintrc-default
@@ -39,6 +39,7 @@
         "no-lonely-if": 2,
         "no-multiple-empty-lines": [1, { "max": 2 }],
         "no-nested-ternary": 2,
+        "no-underscore-dangle": 0,
         "no-unneeded-ternary": 2,
         "object-curly-spacing": 2,
         "one-var": [2, "never"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coding-standards",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "60fram.es coding standards.",
   "main": "",
   "scripts": {


### PR DESCRIPTION
The eslint docs are terrible at indicating which rules are on by default, looks like this was on.
