### PR TITLE
Allow arrow functions

### DIFF
--- a/.eslintrc-default
+++ b/.eslintrc-default
@@ -32,7 +32,7 @@
         "comma-style": 2,
         "computed-property-spacing": 2,
         "consistent-this": [2, "self"],
-        "func-style": [2, "declaration"],
+        "func-style": [2, "declaration", { "allowArrowFunctions": true }],
         "indent": 2,
         "linebreak-style": 2,
         "max-nested-callbacks": [2, 3],


### PR DESCRIPTION
The below was invalid:

```
const C = () => (
    <div />
);
```

http://eslint.org/docs/rules/func-style
